### PR TITLE
Added Postfix Relayhost Configuration Variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ Image: anonaddy/anonaddy:latest
 * `POSTFIX_SMTPD_TLS_CERT_FILE`: File with the Postfix SMTP server RSA certificate in PEM format
 * `POSTFIX_SMTPD_TLS_KEY_FILE`: File with the Postfix SMTP server RSA private key in PEM format
 * `POSTFIX_SMTP_TLS`: Enabling TLS in the Postfix SMTP client (default `false`)
+* `POSTFIX_RELAYHOST`: Default host to send mail to (default empty, direct delivery to destination)
+* `POSTFIX_RELAYHOST_AUTH_ENABLE`: Enable client-side authentication for relayhost (default `false`)
+* `POSTFIX_RELAYHOST_USERNAME`: Postfix SMTP Client username for relayhost authentication
+* `POSTFIX_RELAYHOST_PASSWORD`: Postfix SMTP Client password for relayhost authentication
 
 ### DKIM
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Image: anonaddy/anonaddy:latest
 * `POSTFIX_SMTPD_TLS_CERT_FILE`: File with the Postfix SMTP server RSA certificate in PEM format
 * `POSTFIX_SMTPD_TLS_KEY_FILE`: File with the Postfix SMTP server RSA private key in PEM format
 * `POSTFIX_SMTP_TLS`: Enabling TLS in the Postfix SMTP client (default `false`)
-* `POSTFIX_RELAYHOST`: Default host to send mail to (default empty, direct delivery to destination)
+* `POSTFIX_RELAYHOST`: Default host to send mail to
 * `POSTFIX_RELAYHOST_AUTH_ENABLE`: Enable client-side authentication for relayhost (default `false`)
 * `POSTFIX_RELAYHOST_USERNAME`: Postfix SMTP Client username for relayhost authentication
 * `POSTFIX_RELAYHOST_PASSWORD`: Postfix SMTP Client password for relayhost authentication

--- a/rootfs/etc/cont-init.d/03-config.sh
+++ b/rootfs/etc/cont-init.d/03-config.sh
@@ -352,7 +352,7 @@ append_dot_mydomain = no
 virtual_transport = anonaddy:
 virtual_mailbox_domains = ${VBOX_DOMAINS},mysql:/etc/postfix/mysql-virtual-alias-domains-and-subdomains.cf
 
-relayhost =
+relayhost = ${POSTFIX_RELAYHOST}
 mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16
 mailbox_size_limit = 0
 recipient_delimiter = +
@@ -460,6 +460,28 @@ smtp_tls_mandatory_exclude_ciphers = MD5, DES, ADH, RC4, PSD, SRP, 3DES, eNULL, 
 smtp_tls_exclude_ciphers = MD5, DES, ADH, RC4, PSD, SRP, 3DES, eNULL, aNULL
 smtp_tls_security_level = may
 EOL
+fi
+
+if [ "$POSTFIX_RELAYHOST_AUTH_ENABLE" = "true" ]; then
+  echo "Setting Postfix SASL configuration"
+  cat >> /etc/postfix/main.cf <<EOL
+
+smtp_sasl_auth_enable = yes
+smtp_sasl_password_maps = texthash:/etc/postfix/sasl_passwd
+smtp_sasl_security_options = noanonymous
+smtp_sasl_tls_security_options = noanonymous
+smtp_tls_security_level = encrypt
+header_size_limit = 4096000
+EOL
+
+  cat >> /etc/postfix/sasl_passwd <<EOL
+
+${POSTFIX_RELAYHOST} ${POSTFIX_RELAYHOST_USERNAME}:${POSTFIX_RELAYHOST_PASSWORD}
+EOL
+
+chmod 600 /etc/postfix/sasl_passwd
+postmap /etc/postfix/sasl_passwd
+
 fi
 
 echo "Creating Postfix virtual alias domains and subdomains configuration"

--- a/rootfs/etc/cont-init.d/03-config.sh
+++ b/rootfs/etc/cont-init.d/03-config.sh
@@ -74,6 +74,9 @@ MAIL_FROM_ADDRESS=${MAIL_FROM_ADDRESS:-anonaddy@${ANONADDY_DOMAIN}}
 POSTFIX_DEBUG=${POSTFIX_DEBUG:-false}
 POSTFIX_SMTPD_TLS=${POSTFIX_SMTPD_TLS:-false}
 POSTFIX_SMTP_TLS=${POSTFIX_SMTP_TLS:-false}
+POSTFIX_RELAYHOST_AUTH_ENABLE=${POSTFIX_RELAYHOST_AUTH_ENABLE:-false}
+POSTFIX_RELAYHOST_USERNAME=${POSTFIX_RELAYHOST_USERNAME:-null}
+POSTFIX_RELAYHOST_PASSWORD=${POSTFIX_RELAYHOST_PASSWORD:-null}
 
 DKIM_ENABLE=${DKIM_ENABLE:-false}
 DKIM_PRIVATE_KEY=/data/dkim/${ANONADDY_DOMAIN}.private
@@ -470,7 +473,6 @@ smtp_sasl_auth_enable = yes
 smtp_sasl_password_maps = texthash:/etc/postfix/sasl_passwd
 smtp_sasl_security_options = noanonymous
 smtp_sasl_tls_security_options = noanonymous
-smtp_tls_security_level = encrypt
 header_size_limit = 4096000
 EOL
 


### PR DESCRIPTION
Fixes #33 

Added basic environment variables to allow configuration of postfix relayhost and optional authentication. ( as requested in #33 )

Default behavior remains the same (relayhost = <empty>), but it will now be possible to use a relay like sendgrid or gmail to send and forward emails from AnonAddy docker image. 