### PR TITLE
Add apex domain to signing table

### DIFF
--- a/rootfs/etc/cont-init.d/03-config.sh
+++ b/rootfs/etc/cont-init.d/03-config.sh
@@ -269,7 +269,8 @@ EOL
 
   echo "Setting OpenDKIM signing table"
   cat > /etc/opendkim/signing.table <<EOL
-*.${ANONADDY_DOMAIN}    default._domainkey.${ANONADDY_DOMAIN}
+*@${ANONADDY_DOMAIN}    default._domainkey.${ANONADDY_DOMAIN}
+*@*.${ANONADDY_DOMAIN}    default._domainkey.${ANONADDY_DOMAIN}
 EOL
 
   echo "Setting OpenDKIM key table"


### PR DESCRIPTION
As proposed by @willbrowningme in [this issue](#47), I implemented and verified the functionality of the change to support both the apex domain and subdomains instead of just the subdomains of a given domain. Conveniently and if needed for further verification, the corresponding docker image with applied changes is located [here](https://hub.docker.com/r/flash1232/anonaddy).