### PR TITLE
align with anonaddy self hosting docs and generate dkim using rspamd

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,11 +255,15 @@ docker-compose exec anonaddy anonaddy anonaddy:create-user "username" "webmaster
 ```shell
 docker-compose run --entrypoint '' anonaddy gen-dkim
 ```
+
 ```text
-opendkim-genkey: generating private key
-opendkim-genkey: private key written to example.com.private
-opendkim-genkey: extracting public key
-opendkim-genkey: DNS TXT record written to example.com.txt
+generating private and storing in data/dkim/example.com.private
+generating DNS TXT record with public key and storing it in data/dkim/example.com.txt
+
+default._domainkey IN TXT ( "v=DKIM1; k=rsa; "
+        "p=***"
+        "***"
+) ;
 ```
 
 The keypair will be available in `/data/dkim`.

--- a/rootfs/usr/local/bin/gen-dkim
+++ b/rootfs/usr/local/bin/gen-dkim
@@ -4,14 +4,17 @@
 DKIM_PRIVATE_KEY=/data/dkim/${ANONADDY_DOMAIN}.private
 
 if [ -z "$ANONADDY_DOMAIN" ]; then
-  >&2 echo "ERROR: ANONADDY_DOMAIN must be defined"
+  echo >&2 "ERROR: ANONADDY_DOMAIN must be defined"
   exit 1
 fi
 if [ -f "$DKIM_PRIVATE_KEY" ]; then
-  >&2 echo "ERROR: $DKIM_PRIVATE_KEY already exists"
+  echo >&2 "ERROR: $DKIM_PRIVATE_KEY already exists"
   exit 1
 fi
 
 mkdir -p /data/dkim
-opendkim-genkey -b 2048 -d "${ANONADDY_DOMAIN}" -D /data/dkim -s "${ANONADDY_DOMAIN}" -v
+echo "generating private and storing in ${DKIM_PRIVATE_KEY}"
+echo "generating DNS TXT record with public key and storing it in /data/dkim/${ANONADDY_DOMAIN}.txt"
+echo ""
+rspamadm dkim_keygen -s 'default' -b 2048 -d "${ANONADDY_DOMAIN}" -k "${DKIM_PRIVATE_KEY}" | tee -a "/data/dkim/${ANONADDY_DOMAIN}.txt"
 chown -R anonaddy. /data/dkim


### PR DESCRIPTION
during review of #96 `gen-dkim` was noticed to be using `opendkim-genkey` and that anonaddy's self hosting docs recommend using `rspamd` to generate dkim keys.

this PR migrates that script to align with the docs