### PR TITLE
Fix: emails forwarded even if alias is disabled

### DIFF
--- a/rootfs/etc/cont-init.d/15-config-postfix.sh
+++ b/rootfs/etc/cont-init.d/15-config-postfix.sh
@@ -75,7 +75,6 @@ smtpd_sender_restrictions =
     reject_unknown_reverse_client_hostname
 
 smtpd_recipient_restrictions =
-    permit_mynetworks,
     reject_unauth_destination,
     check_recipient_access mysql:/etc/postfix/mysql-recipient-access.cf,
     #check_policy_service unix:private/policyd-spf


### PR DESCRIPTION
This PR propagates an upstream (anonaddy/anonaddy) bugfix to this repo. 

- Upstream issue: anonaddy/anonaddy#72
- Issue on this repo: #121 

