### PR TITLE
Readme update - replace expired Spamhaus link

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,9 +314,8 @@ from=<sender@example.com> to=<recipient@example.com> proto=ESMTP helo=<icinga2.i
 ```
 
 To fix this issue, you can register a DQS key [here](https://www.spamhaustech.com/dqs/)
-and complete the registration procedure. After you register an account, go to
-[this page](https://portal.spamhaustech.com/dqs/), and you'll find the
-DQS key under section "1.0 Datafeed Query Service".
+and complete the registration procedure. After you register an account, you can find the DQS key in the "Access" section of
+[this page](https://portal.spamhaustech.com/dqs/).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ from=<sender@example.com> to=<recipient@example.com> proto=ESMTP helo=<icinga2.i
 
 To fix this issue, you can register a DQS key [here](https://www.spamhaustech.com/dqs/)
 and complete the registration procedure. After you register an account, go to
-[this page](https://portal.spamhaustech.com/manuals/dqs/), and you'll find the
+[this page](https://portal.spamhaustech.com/dqs/), and you'll find the
 DQS key under section "1.0 Datafeed Query Service".
 
 ## Contributing


### PR DESCRIPTION
A link in the DQS section was pointing to a page that no longer exists. Updated the link/description.