### PR TITLE
Change rspamd executable dir

### DIFF
--- a/rootfs/etc/cont-init.d/60-svc-rspamd.sh
+++ b/rootfs/etc/cont-init.d/60-svc-rspamd.sh
@@ -25,6 +25,6 @@ mkdir -p /etc/services.d/rspamd
 cat >/etc/services.d/rspamd/run <<EOL
 #!/usr/bin/execlineb -P
 with-contenv
-/usr/sbin/rspamd -i -f -u rspamd -g rspamd
+/usr/bin/rspamd -i -f -u rspamd -g rspamd
 EOL
 chmod +x /etc/services.d/rspamd/run


### PR DESCRIPTION
I noticed a bunch of
> exec: fatal: unable to exec /usr/sbin/rspamd: No such file or directory

lines lately.

I manually tried settings this: 
https://github.com/anonaddy/docker/blob/b42a529fed3a83dcb1954a9702eaa689ba149228/rootfs/etc/cont-init.d/60-svc-rspamd.sh#L28

to `/usr/bin/rspamd` instead of `/usr/sbin/rspamd`.

That seems to solve the problem.