### PR TITLE
Document that Rspamd must be enabled for reply to work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,12 @@ Image: anonaddy/anonaddy:latest
 >
 > Rspamd service is disabled if DKIM private key is not found
 
+> **Warning**
+>
+> Rspamd service needs to be enabled for the reply anonymously feature to work.  
+> See [#169](https://github.com/anonaddy/docker/issues/169#issuecomment-1232577449) for more details.
+
+
 ## Volumes
 
 * `/data`: Contains storage


### PR DESCRIPTION
As mentioned in #169 enabling Rspamd is crucial to getting the anon reply feature to work.

Therefore it's now documented in the README.
