### PR TITLE
Define Return Codes for Spamhaus in Postfix

### DIFF
--- a/rootfs/etc/cont-init.d/15-config-postfix.sh
+++ b/rootfs/etc/cont-init.d/15-config-postfix.sh
@@ -93,10 +93,11 @@ smtpd_recipient_restrictions =
     permit_mynetworks,
     reject_unauth_destination,
     check_policy_service unix:private/policy,
-    reject_rhsbl_helo ${DBL_DOMAIN},
-    reject_rhsbl_reverse_client ${DBL_DOMAIN},
-    reject_rhsbl_sender ${DBL_DOMAIN},
-    reject_rbl_client ${ZEN_DOMAIN}
+    reject_rbl_client ${ZEN_DOMAIN}=127.0.0.[2..11],
+    reject_rhsbl_sender ${DBL_DOMAIN}=127.0.1.[2..99],
+    reject_rhsbl_helo ${DBL_DOMAIN}=127.0.1.[2..99],
+    reject_rhsbl_reverse_client ${DBL_DOMAIN}=127.0.1.[2..99],
+    warn_if_reject reject_rbl_client ${ZEN_DOMAIN}=127.255.255.[1..255],
     reject_rbl_client dul.dnsbl.sorbs.net
 
 # Block clients that speak too early.


### PR DESCRIPTION
Getting a Spamhaus DQS key is not possible anymore like before. Therefore it would make sense to just warn instead of rejecting messages where the rate limit hits.

Changes according to the official Spamhaus docs: https://docs.spamhaus.com/datasets/docs/source/40-real-world-usage/PublicMirrors/MTAs/020-Postfix.html