### PR TITLE
Make the database root user require a password.

### DIFF
--- a/examples/compose/compose.yml
+++ b/examples/compose/compose.yml
@@ -11,7 +11,6 @@ services:
     volumes:
       - "./db:/var/lib/mysql"
     environment:
-      - "MYSQL_ALLOW_EMPTY_PASSWORD=yes"
       - "MYSQL_DATABASE"
       - "MYSQL_USER"
       - "MYSQL_PASSWORD"

--- a/examples/nginx/compose.yml
+++ b/examples/nginx/compose.yml
@@ -11,7 +11,6 @@ services:
     volumes:
       - "./db:/var/lib/mysql"
     environment:
-      - "MYSQL_ALLOW_EMPTY_PASSWORD=yes"
       - "MYSQL_DATABASE"
       - "MYSQL_USER"
       - "MYSQL_PASSWORD"

--- a/examples/rspamd/compose.yml
+++ b/examples/rspamd/compose.yml
@@ -11,7 +11,6 @@ services:
     volumes:
       - "./db:/var/lib/mysql"
     environment:
-      - "MYSQL_ALLOW_EMPTY_PASSWORD=yes"
       - "MYSQL_DATABASE"
       - "MYSQL_USER"
       - "MYSQL_PASSWORD"

--- a/examples/traefik/compose.yml
+++ b/examples/traefik/compose.yml
@@ -45,7 +45,6 @@ services:
     volumes:
       - "./db:/var/lib/mysql"
     environment:
-      - "MYSQL_ALLOW_EMPTY_PASSWORD=yes"
       - "MYSQL_DATABASE"
       - "MYSQL_USER"
       - "MYSQL_PASSWORD"


### PR DESCRIPTION
With `MYSQL_ALLOW_EMPTY_PASSWORD=yes`
and no `MYSQL_ROOT_PASSWORD` set,
 it will use the default `MYSQL_ROOT_PASSWORD=`,
resulting in the **root user having an EMPTY PASSWORD per default**,
too easily resulting in https://github.com/anonaddy/docker/issues/272.


![5220223266285805472-y](https://github.com/anonaddy/docker/assets/2737108/73064ab1-7f08-4a08-adc0-4f72a163126a)
