### PR TITLE
examples: generate random password for db root

### DIFF
--- a/examples/compose/compose.yml
+++ b/examples/compose/compose.yml
@@ -2,7 +2,7 @@ name: addy
 
 services:
   db:
-    image: mariadb:10.5
+    image: mariadb:10
     container_name: addy_db
     command:
       - "mysqld"

--- a/examples/compose/compose.yml
+++ b/examples/compose/compose.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - "./db:/var/lib/mysql"
     environment:
-      - "MYSQL_ALLOW_EMPTY_PASSWORD=yes"
+      - "MARIADB_RANDOM_ROOT_PASSWORD=yes"
       - "MYSQL_DATABASE"
       - "MYSQL_USER"
       - "MYSQL_PASSWORD"

--- a/examples/nginx/compose.yml
+++ b/examples/nginx/compose.yml
@@ -2,7 +2,7 @@ name: addy
 
 services:
   db:
-    image: mariadb:10.5
+    image: mariadb:10
     container_name: addy_db
     command:
       - "mysqld"

--- a/examples/nginx/compose.yml
+++ b/examples/nginx/compose.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - "./db:/var/lib/mysql"
     environment:
-      - "MYSQL_ALLOW_EMPTY_PASSWORD=yes"
+      - "MARIADB_RANDOM_ROOT_PASSWORD=yes"
       - "MYSQL_DATABASE"
       - "MYSQL_USER"
       - "MYSQL_PASSWORD"

--- a/examples/rspamd/compose.yml
+++ b/examples/rspamd/compose.yml
@@ -2,7 +2,7 @@ name: annoaddy
 
 services:
   db:
-    image: mariadb:10.5
+    image: mariadb:10
     container_name: addy_db
     command:
       - "mysqld"

--- a/examples/rspamd/compose.yml
+++ b/examples/rspamd/compose.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - "./db:/var/lib/mysql"
     environment:
-      - "MYSQL_ALLOW_EMPTY_PASSWORD=yes"
+      - "MARIADB_RANDOM_ROOT_PASSWORD=yes"
       - "MYSQL_DATABASE"
       - "MYSQL_USER"
       - "MYSQL_PASSWORD"

--- a/examples/traefik/compose.yml
+++ b/examples/traefik/compose.yml
@@ -36,7 +36,7 @@ services:
     restart: always
 
   db:
-    image: mariadb:10.5
+    image: mariadb:10
     container_name: addy_db
     command:
       - "mysqld"

--- a/examples/traefik/compose.yml
+++ b/examples/traefik/compose.yml
@@ -45,7 +45,7 @@ services:
     volumes:
       - "./db:/var/lib/mysql"
     environment:
-      - "MYSQL_ALLOW_EMPTY_PASSWORD=yes"
+      - "MARIADB_RANDOM_ROOT_PASSWORD=yes"
       - "MYSQL_DATABASE"
       - "MYSQL_USER"
       - "MYSQL_PASSWORD"

--- a/test/compose.yml
+++ b/test/compose.yml
@@ -2,7 +2,7 @@ name: addy
 
 services:
   db:
-    image: mariadb:10.5
+    image: mariadb:10
     container_name: addy_db
     networks:
       - addy

--- a/test/compose.yml
+++ b/test/compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - "db:/var/lib/mysql"
     environment:
-      - "MYSQL_ALLOW_EMPTY_PASSWORD=yes"
+      - "MARIADB_RANDOM_ROOT_PASSWORD=yes"
       - "MYSQL_DATABASE"
       - "MYSQL_USER"
       - "MYSQL_PASSWORD"


### PR DESCRIPTION
fixes https://github.com/anonaddy/docker/issues/272
closes #273 

https://github.com/anonaddy/docker/actions/runs/9241557539/job/25423206424#step:9:66

```
addy_db     | 2024-05-26 07:29:26+00:00 [Note] [Entrypoint]: Temporary server started.
addy_db     | 2024-05-26 07:29:27+00:00 [Note] [Entrypoint]: GENERATED ROOT PASSWORD: DX6WyL!hIC`yy2*J(OE$P<Sq3+He/l7[
addy_db     | 2024-05-26 07:29:27+00:00 [Note] [Entrypoint]: Creating database addy
addy_db     | 2024-05-26 07:29:27+00:00 [Note] [Entrypoint]: Creating user addy
addy_db     | 2024-05-26 07:29:27+00:00 [Note] [Entrypoint]: Giving user addy access to schema addy
addy_db     | 2024-05-26 07:29:27+00:00 [Note] [Entrypoint]: Securing system users (equivalent to running mysql_secure_installation)
```