### PR TITLE
feat: make SMTPD_MILTERS configurable via addy.env

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ linux/arm64
 * `RSPAMD_ENABLE`: Enable Rspamd service. (default `false`)
 * `RSPAMD_WEB_PASSWORD`: Rspamd web password (default `null`)
 * `RSPAMD_NO_LOCAL_ADDRS`: Disable Rspamd local networks (default `false`)
+* `RSPAMD_SMTPD_MILTERS`: A list of Milter (space or comma as separated) applications for new mail that arrives (default `inet:127.0.0.1:11332`)
 
 > [!NOTE]
 > `RSPAMD_WEB_PASSWORD_FILE` can be used to fill in the value from a file,

--- a/rootfs/etc/cont-init.d/00-env
+++ b/rootfs/etc/cont-init.d/00-env
@@ -97,7 +97,7 @@ DKIM_PRIVATE_KEY=/data/dkim/${ANONADDY_DOMAIN}.private
 
 SMTPD_MILTERS=""
 if [ "$RSPAMD_ENABLE" = "true" ] && [ -f "$DKIM_PRIVATE_KEY" ]; then
-  SMTPD_MILTERS="inet:127.0.0.1:11332"
+  SMTPD_MILTERS=${RSPAMD_SMTPD_MILTERS:-inet:127.0.0.1:11332}
 fi
 
 # Keep them to check if users are still using an old configuration


### PR DESCRIPTION
This pull request makes the `SMTPD_MILTERS` setting configurable via the `addy.env` to allow for greater flexibility in RSPAMD/Postfix setup. For example, this makes it possible to use a remote Milter service instead of running it locally.

Changes:
- Added functionality to override SMTPD_MILTERS value through addy.env file.
- Default value for SMTPD_MILTERS is set to inet:127.0.0.1:11332 if not specified.