### PR TITLE
added option for SSL encryption for postfix relay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,8 @@ RUN apk --no-cache add \
     shadow \
     tar \
     tzdata \
+    cyrus-sasl \
+    cyrus-sasl-login \
   && cp /etc/postfix/master.cf /etc/postfix/master.cf.orig \
   && cp /etc/postfix/main.cf /etc/postfix/main.cf.orig \
   && apk --no-cache add -t build-dependencies \

--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ linux/arm64
 * `POSTFIX_RELAYHOST_AUTH_ENABLE`: Enable client-side authentication for relayhost (default `false`)
 * `POSTFIX_RELAYHOST_USERNAME`: Postfix SMTP Client username for relayhost authentication
 * `POSTFIX_RELAYHOST_PASSWORD`: Postfix SMTP Client password for relayhost authentication
-* `POSTFIX_SPAMHAUS_DQS_KEY`: Personal key for [Spamhaus DQS](#spamhaus-dqs-configuration)
+* `POSTFIX_RELAYHOST_SSL_ENCRYPTION`: Set to `true` to enable SSL encrpytion over SMTP where TLS is not available.
+* `POSTFIX_SPAMAUS_DQS_KEY`: Personal key for [Spamhaus DQS](#spamhaus-dqs-configuration)
 
 > [!NOTE]
 > `POSTFIX_RELAYHOST_USERNAME_FILE` and `POSTFIX_RELAYHOST_PASSWORD_FILE` can be

--- a/rootfs/etc/cont-init.d/15-config-postfix.sh
+++ b/rootfs/etc/cont-init.d/15-config-postfix.sh
@@ -165,6 +165,15 @@ smtp_tls_mandatory_ciphers = high
 smtp_tls_ciphers = high
 smtp_tls_mandatory_exclude_ciphers = MD5, DES, ADH, RC4, PSD, SRP, 3DES, eNULL, aNULL
 smtp_tls_exclude_ciphers = MD5, DES, ADH, RC4, PSD, SRP, 3DES, eNULL, aNULL
+EOL
+
+if [ "$POSTFIX_RELAYHOST_SSL_ENCRYPTION" = "true" ]; then
+  cat >>/etc/postfix/main.cf <<EOL
+smtp_tls_wrappermode = yes
+smtp_tls_security_level = encrypt
+EOL
+else
+  cat >>/etc/postfix/main.cf <<EOL
 smtp_tls_security_level = may
 EOL
 fi


### PR DESCRIPTION
sorry for the old request, I am not really great with gihub as of yet :), I have redone the changes with some new formatting, change as you see fit

the main issue while I was configuring a new relay (namecrane.com) it does not currently support TLS on either 465 or 587 so I was attempting to get it working as a relay using SSL and this change was required to get it working

```
Jan 14 21:41:58 mail postfix/smtp[932]: SMTPS wrappermode (TCP port 465) requires setting "smtp_tls_wrappermode = yes", and "smtp_tls_security_level = encrypt" (or stronger)
```

I have tested it with purelymail.com on port 465 also,

with the option `POSTFIX_RELAYHOST_SSL_ENCRYPTION` enabled TLS will not work