### PR TITLE
Removes deprecated postfix config

### DIFF
--- a/rootfs/etc/cont-init.d/15-config-postfix.sh
+++ b/rootfs/etc/cont-init.d/15-config-postfix.sh
@@ -125,7 +125,6 @@ if [ "$POSTFIX_SMTPD_TLS" = "true" ]; then
   cat >>/etc/postfix/main.cf <<EOL
 
 # SMTPD
-smtpd_use_tls=yes
 smtpd_tls_session_cache_database = lmdb:\${data_directory}/smtpd_scache
 smtpd_tls_CApath = /etc/ssl/certs
 smtpd_tls_security_level = may
@@ -156,7 +155,6 @@ if [ "$POSTFIX_SMTP_TLS" = "true" ]; then
 
 # SMTP
 smtp_tls_CApath = /etc/ssl/certs
-smtp_use_tls=yes
 smtp_tls_loglevel = 1
 smtp_tls_session_cache_database = lmdb:\${data_directory}/smtp_scache
 smtp_tls_mandatory_protocols = !SSLv2, !SSLv3, !TLSv1

--- a/rootfs/etc/cont-init.d/15-config-postfix.sh
+++ b/rootfs/etc/cont-init.d/15-config-postfix.sh
@@ -136,7 +136,6 @@ smtpd_tls_exclude_ciphers = MD5, DES, ADH, RC4, PSD, SRP, 3DES, eNULL, aNULL
 smtpd_tls_mandatory_protocols = !SSLv2, !SSLv3, !TLSv1
 smtpd_tls_mandatory_ciphers = high
 smtpd_tls_ciphers = high
-smtpd_tls_eecdh_grade = ultra
 tls_high_cipherlist=EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH+aRSA+RC4:EECDH:EDH+aRSA:RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS
 tls_preempt_cipherlist = yes
 tls_ssl_options = NO_COMPRESSION


### PR DESCRIPTION
During startup postfix logs some deprecation warnings:

```
[16-Mar-2025 09:10:36] NOTICE: ready to handle connections
/usr/sbin/postconf: warning: /etc/postfix/main.cf: support for parameter "smtpd_tls_eecdh_grade" will be removed; instead, do not specify (leave at default)
/usr/sbin/postconf: warning: /etc/postfix/main.cf: support for parameter "smtp_use_tls" will be removed; instead, specify "smtp_tls_security_level"
/usr/sbin/postconf: warning: /etc/postfix/main.cf: support for parameter "smtpd_use_tls" will be removed; instead, specify "smtpd_tls_security_level"
```

This PR takes care to remove them, as both do not require an replacement or already have the proper alternatives configured.