### PR TITLE
Enhance Postfix TLS Configuration (with ECC Support) and Domain Exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,15 +158,18 @@ linux/arm64
 
 * `POSTFIX_DEBUG`: Enable debug (default `false`)
 * `POSTFIX_MESSAGE_SIZE_LIMIT`: The maximal size in bytes of a message, including envelope information (default `26214400`)
-* `POSTFIX_SMTPD_TLS`: Enabling TLS in the Postfix SMTP server (default `false`)
+* `POSTFIX_SMTPD_TLS`: Enabling TLS in the Postfix SMTP server (default `false`, possible values: `true`|`may`|`encrypt`|`ask`|`require`, see [Postfix TLS README](https://www.postfix.org/TLS_README.html#client_tls_levels))
 * `POSTFIX_SMTPD_TLS_CERT_FILE`: File with the Postfix SMTP server RSA certificate in PEM format
-* `POSTFIX_SMTPD_TLS_KEY_FILE`: File with the Postfix SMTP server RSA private key in PEM format
-* `POSTFIX_SMTP_TLS`: Enabling TLS in the Postfix SMTP client (default `false`)
+* `POSTFIX_SMTPD_TLS_ECCERT_FILE`: File with the Postfix SMTP server RSA private key in PEM format
+* `POSTFIX_SMTPD_TLS_ECKEY_FILE`: File with the Postfix SMTP server ECC certificate in PEM format
+* `POSTFIX_SMTPD_TLS_KEY_FILE`: File with the Postfix SMTP server ECC private key in PEM format
+* `POSTFIX_SMTP_TLS`: Enabling TLS in the Postfix SMTP client (default `false`, possible values: `true`|`may`|`encrypt`|`dane`|`dane-only`|`verify`|`secure`, see [Postfix TLS README](https://www.postfix.org/TLS_README.html#server_vrfy_client))
 * `POSTFIX_RELAYHOST`: Default host to send mail to
 * `POSTFIX_RELAYHOST_AUTH_ENABLE`: Enable client-side authentication for relayhost (default `false`)
 * `POSTFIX_RELAYHOST_USERNAME`: Postfix SMTP Client username for relayhost authentication
 * `POSTFIX_RELAYHOST_PASSWORD`: Postfix SMTP Client password for relayhost authentication
-* `POSTFIX_RELAYHOST_SSL_ENCRYPTION`: enable SSL encrpytion over SMTP where TLS is not available. (default `false`)
+* `POSTFIX_RELAYHOST_SSL_ENCRYPTION`: enable SSL encrpytion over SMTP where TLS is not available. (default `false`, possible values: `true`|`tls_policy`, `tls_policy` uses the policy defined by `POSTFIX_SMTP_TLS`)
+* `POSTFIX_SMTP_TLS_DOMAINS_EXCEPTIONS`: Comma-separated list of domains with TLS exceptions (`TLS policy`: `may`)
 * `POSTFIX_SPAMAUS_DQS_KEY`: Personal key for [Spamhaus DQS](#spamhaus-dqs-configuration)
 
 > [!NOTE]

--- a/rootfs/etc/cont-init.d/15-config-postfix.sh
+++ b/rootfs/etc/cont-init.d/15-config-postfix.sh
@@ -166,7 +166,7 @@ EOL
   [[ "$POSTFIX_SMTPD_TLS" == "require" ]] && echo "smtpd_tls_req_ccert = yes" >>/etc/postfix/main.cf
 fi
 
-if [[ "$POSTFIX_SMTP_TLS" =~ ^(true|encrypt|dane|dane-only|verify|secure)$ ]]; then
+if [[ "$POSTFIX_SMTP_TLS" =~ ^(true|may|encrypt|dane|dane-only|verify|secure)$ ]]; then
   echo "Setting Postfix smtp TLS configuration"
   cat >>/etc/postfix/main.cf <<EOL
 

--- a/rootfs/etc/cont-init.d/15-config-postfix.sh
+++ b/rootfs/etc/cont-init.d/15-config-postfix.sh
@@ -155,10 +155,10 @@ EOL
   fi
   
   # TLS policy for smtpd
-  if [[ "$POSTFIX_SMTPD_TLS" == "true" ]]; then
+  if [[ "$POSTFIX_SMTPD_TLS" =~ ^(true|may)$ ]]; then
     echo "smtpd_tls_security_level = may" >>/etc/postfix/main.cf  # Default value if true
   else
-    echo "smtpd_tls_security_level = $POSTFIX_SMTPD_TLS" >>/etc/postfix/main.cf
+    echo "smtpd_tls_security_level = encrypt" >>/etc/postfix/main.cf
   fi
 
   # Additional options for client certificates
@@ -199,7 +199,7 @@ EOL
     echo "smtp_dns_support_level = dnssec" >>/etc/postfix/main.cf
   fi
 
-  if [ "$POSTFIX_RELAYHOST_SSL_ENCRYPTION" = "true" ]; then
+  if [[ "$POSTFIX_RELAYHOST_SSL_ENCRYPTION" =~ ^(true|tls_policy)$ ]]; then
     cat >>/etc/postfix/main.cf <<EOL
 smtp_tls_wrappermode = yes
 EOL


### PR DESCRIPTION
- Implemented more specific TLS configuration for Postfix, allowing flexible security levels based on environment variables.
- Added support for ECC certificates and keys.
- Introduced domain exceptions via the POSTFIX_SMTP_TLS_EXCEPTIONS variable to set smtp_tls_security_level to "may" for specified domains.

________________________________________________________________________________________
**Note:** It is advisable to update the following line:
```plaintext
smtpd_tls_protocols = !SSLv2, !SSLv3, !TLSv1
```
to 
```plaintext
smtpd_tls_protocols = >=TLSv1.2
```
This change will ensure that your server supports TLS connections starting from version 1.2 and above, enhancing security. For more details, please refer to the [Postfix Documentation](https://www.postfix.org/postconf.5.html#smtpd_tls_protocols).
_Please note that this change has not been made in this pull request._