### PR TITLE
Fix DKIM for all domains

### DIFF
--- a/rootfs/usr/local/bin/gen-dkim
+++ b/rootfs/usr/local/bin/gen-dkim
@@ -1,6 +1,9 @@
 #!/usr/bin/env sh
 
-#ANONADDY_DOMAIN=${ANONADDY_DOMAIN:-null}
+ANONADDY_DOMAIN=${1}
+if [ -z "${ANONADDY_DOMAIN}" ]; then
+    ANONADDY_DOMAIN=${ANONADDY_DOMAIN:-null};
+fi
 DKIM_PRIVATE_KEY=/data/dkim/${ANONADDY_DOMAIN}.private
 
 if [ -z "$ANONADDY_DOMAIN" ]; then


### PR DESCRIPTION
Currently if you add additional domains to ANONADDY_DOMAINS_ALL they are ignored and emails sent from any of these additional domains will fail DKIM validation.  This pull request attempts to resolve this.

The user will need to add a number of DNS records to their registrar to fully implement the fix.

TXT ${ANONADDY_DKIM_SELECTOR}._domainkey.${YOUR_DOMAIN_NAME} ${PUBLIC_DKIM_KEY}
MX ${YOUR_DOMAIN_NAME} ${ANONADDY_DOMAIN}.
TXT ${YOUR_DOMAIN_NAME} "v=spf1 mx include:${ANONADDY_DOMAIN} ~all"
TXT _dmarc.${YOUR_DOMAIN_NAME} "v=DMARC1; p=reject; rua=mailto:postmaster@${YOUR_DOMAIN_NAME}; ruf=mailto:postmaster@${YOUR_DOMAIN_NAME}; pct=100; adkim=r; aspf=r"

gen-dkim has been amended to allow a value to be passed to it to help automate the process.