### PR TITLE
rspamd: allow not enabling greylisting

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ linux/arm64
 * `RSPAMD_WEB_PASSWORD`: Rspamd web password (default `null`)
 * `RSPAMD_NO_LOCAL_ADDRS`: Disable Rspamd local networks (default `false`)
 * `RSPAMD_SMTPD_MILTERS`: A list of Milter (space or comma as separated) applications for new mail that arrives (default `inet:127.0.0.1:11332`)
+* `RSPAMD_GREYLIST_ENABLE`: Whether to enable greylisting in rspamd (default `true`)
 
 > [!NOTE]
 > `RSPAMD_WEB_PASSWORD_FILE` can be used to fill in the value from a file,

--- a/rootfs/etc/cont-init.d/14-config-rspamd.sh
+++ b/rootfs/etc/cont-init.d/14-config-rspamd.sh
@@ -94,10 +94,16 @@ password = "${REDIS_PASSWORD}";
 read_servers = "${REDIS_HOST}";
 EOL
 
+if [ "${RSPAMD_GREYLIST_ENABLE:-true}" = true ]
+then
   echo "Setting Rspamd greylist.conf"
   cat >/etc/rspamd/local.d/greylist.conf <<EOL
 servers = "${REDIS_HOST}:${REDIS_PORT}";
 EOL
+else
+  echo "Disabling greylisting"
+  echo "enabled = false;" > /etc/rspamd/override.d/greylist.conf
+fi
 
   echo "Setting Rspamd history_redis.conf"
   cat >/etc/rspamd/local.d/history_redis.conf <<EOL


### PR DESCRIPTION
This allows to not enable the greylisting, which is useful if the anonaddy server is behind another mailserver.

Closes #345