### PR TITLE
Add POSTFIX_STRIP_SENDER_HEADER Environment Variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ linux/arm64
 
 * `POSTFIX_DEBUG`: Enable debug (default `false`)
 * `POSTFIX_MESSAGE_SIZE_LIMIT`: The maximal size in bytes of a message, including envelope information (default `26214400`)
+* `POSTFIX_STRIP_SENDER_HEADER`: Strip the Sender header from incoming emails to prevent SES rejection issues (default `false`)
 * `POSTFIX_SMTPD_TLS`: Enabling TLS in the Postfix SMTP server (default `false`, possible values: `true`|`may`|`encrypt`|`ask`|`require`, see [Postfix TLS README](https://www.postfix.org/TLS_README.html#client_tls_levels))
 * `POSTFIX_SMTPD_TLS_CERT_FILE`: File with the Postfix SMTP server RSA certificate in PEM format
 * `POSTFIX_SMTPD_TLS_ECCERT_FILE`: File with the Postfix SMTP server RSA private key in PEM format

--- a/rootfs/etc/cont-init.d/15-config-postfix.sh
+++ b/rootfs/etc/cont-init.d/15-config-postfix.sh
@@ -257,6 +257,20 @@ EOL
 chmod o= /etc/postfix/mysql-virtual-alias-domains-and-subdomains.cf
 chgrp postfix /etc/postfix/mysql-virtual-alias-domains-and-subdomains.cf
 
+if [ "$POSTFIX_STRIP_SENDER_HEADER" = "true" ]; then
+  echo "Setting Postfix header_checks to strip Sender header"
+  cat >/etc/postfix/header_checks <<EOL
+/^Sender:/      IGNORE
+EOL
+  cat >>/etc/postfix/main.cf <<EOL
+
+# Header checks configuration
+mime_header_checks = regexp:/etc/postfix/header_checks
+header_checks = regexp:/etc/postfix/header_checks
+EOL
+  postmap /etc/postfix/header_checks
+fi
+
 if [ -f "/data/postfix-main.alt.cf" ]; then
   cat "/data/postfix-main.alt.cf" > /etc/postfix/main.cf
 fi


### PR DESCRIPTION
When inbound emails contain a "Sender" header, AnonAddy doesn't strip it off when forwarding the email. This causes problems if you've configured the application to relay emails via Amazon SES, since it validates that ALL email headers (From, Sender, and Return-Path) contain only verified identities in your SES account. If any of these headers contain an unverified domain, SES rejects the entire email with an error like:

```
554 Message rejected: Email address is not verified. The following identities failed the check in region US-WEST-2: no-reply@not-my-domain.com
```

This change adds a POSTFIX_STRIP_SENDER_HEADER env var (default `false`), which will optionally configure Postfix to strip off the "Sender" header from emails if present before attempting to relay them.

To enable Sender header stripping, set the environment variable:
```
POSTFIX_STRIP_SENDER_HEADER=true
```

Fixes #267
Related: https://github.com/anonaddy/anonaddy/issues/471