### PR TITLE
Fix typo in README for Spamhaus DQS key

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ linux/arm64
 * `POSTFIX_RELAYHOST_PASSWORD`: Postfix SMTP Client password for relayhost authentication
 * `POSTFIX_RELAYHOST_SSL_ENCRYPTION`: enable SSL encrpytion over SMTP where TLS is not available. (default `false`, possible values: `true`|`tls_policy`, `tls_policy` uses the policy defined by `POSTFIX_SMTP_TLS`)
 * `POSTFIX_SMTP_TLS_DOMAINS_EXCEPTIONS`: Comma-separated list of domains with TLS exceptions (`TLS policy`: `may`)
-* `POSTFIX_SPAMAUS_DQS_KEY`: Personal key for [Spamhaus DQS](#spamhaus-dqs-configuration)
+* `POSTFIX_SPAMHAUS_DQS_KEY`: Personal key for [Spamhaus DQS](#spamhaus-dqs-configuration)
 
 > [!NOTE]
 > `POSTFIX_RELAYHOST_USERNAME_FILE` and `POSTFIX_RELAYHOST_PASSWORD_FILE` can be


### PR DESCRIPTION
Was pulling my hair out trying to figure out why I couldn't get DQS to work, turns out I just copied a typo'd environment variable 🥲