### PR TITLE
Update AnonAddy Docker from 1.3.8 to 1.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG ANONADDY_VERSION=1.3.7
+ARG ANONADDY_VERSION=1.5.0
 ARG ALPINE_VERSION=3.22
 
 FROM crazymax/yasu:latest AS yasu


### PR DESCRIPTION
## v1.4.0
https://github.com/anonaddy/anonaddy/releases/tag/v1.4.0
- Added new blocklist feature that allows you to block senders by their email address or entire domain
- Added List-Unsubscribe behaviour setting
- Added quick option to add sender to blocklist from failed deliveries page

## v1.4.1
https://github.com/anonaddy/anonaddy/releases/tag/v1.4.1
- Added pinned aliases feature. Pinned aliases will always appear at the top of your alias list.
- Added new `alias_count` filter to the recipients API endpoint, set it to `false` to omit alias count for a faster response.

## v1.5.0
https://github.com/anonaddy/anonaddy/releases/tag/v1.5.0
- Added inbound rejections to failed deliveries
- Added pagination to failed deliveries
- Added inbound/outbound filter to failed deliveries
- Added an email notification when an alias is deactivated or deleted via one-click unsubscribe
- Performance improvements to AccessPolicy and recipient lookups
- Updated self-hosting guide with breaking changes
