### PR TITLE
drop arm/v6 and arm/v7 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,6 @@ $ docker buildx imagetools inspect anonaddy/anonaddy --format "{{json .Manifest}
   jq -r '.manifests[] | select(.platform.os != null and .platform.os != "unknown") | .platform | "\(.os)/\(.architecture)\(if .variant then "/" + .variant else "" end)"'
 
 linux/amd64
-linux/arm/v6
-linux/arm/v7
 linux/arm64
 ```
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -25,8 +25,6 @@ target "image-all" {
   inherits = ["image"]
   platforms = [
     "linux/amd64",
-    "linux/arm/v6",
-    "linux/arm/v7",
     "linux/arm64"
   ]
 }


### PR DESCRIPTION
relates to https://github.com/anonaddy/docker/actions/runs/25261275233/job/74068915471?pr=384#step:10:2079

```
#16 33.52 > vite build
#16 33.52 
#16 33.96 file:///var/www/anonaddy/node_modules/rolldown/dist/shared/binding-s-V_wTpj.mjs:507
#16 33.96 		if (loadErrors.length > 0) throw new Error("Cannot find native binding. npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828). Please try `npm i` again after removing both package-lock.json and node_modules directory.", { cause: loadErrors.reduce((err, cur) => {
#16 33.96 		                                 ^
#16 33.96 
#16 33.96 Error: Cannot find native binding. npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828). Please try `npm i` again after removing both package-lock.json and node_modules directory.
#16 33.96     at file:///var/www/anonaddy/node_modules/rolldown/dist/shared/binding-s-V_wTpj.mjs:507:36
#16 33.96     at file:///var/www/anonaddy/node_modules/rolldown/dist/shared/binding-s-V_wTpj.mjs:9:48
#16 33.96     at file:///var/www/anonaddy/node_modules/rolldown/dist/shared/parse-BywQARUG.mjs:3:46
#16 33.96     at ModuleJob.run (node:internal/modules/esm/module_job:343:25)
#16 33.96     at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:665:26)
#16 33.96     at async CAC.<anonymous> (file:///var/www/anonaddy/node_modules/vite/dist/node/cli.js:764:28) {
#16 33.96   [cause]: Error: Cannot find module '@rolldown/binding-linux-arm-musleabihf'
#16 33.96   Require stack:
#16 33.96   - /var/www/anonaddy/node_modules/rolldown/dist/shared/binding-s-V_wTpj.mjs
#16 33.96       at Function._resolveFilename (node:internal/modules/cjs/loader:1383:15)
#16 33.96       ... 6 lines matching cause stack trace ...
#16 33.96       at require (node:internal/modules/helpers:147:16)
#16 33.96       at requireNative (file:///var/www/anonaddy/node_modules/rolldown/dist/shared/binding-s-V_wTpj.mjs:321:21)
#16 33.96       at file:///var/www/anonaddy/node_modules/rolldown/dist/shared/binding-s-V_wTpj.mjs:475:18 {
#16 33.96     code: 'MODULE_NOT_FOUND',
#16 33.96     requireStack: [
#16 33.96       '/var/www/anonaddy/node_modules/rolldown/dist/shared/binding-s-V_wTpj.mjs'
#16 33.96     ],
#16 33.96     cause: Error: Cannot find module './rolldown-binding.linux-arm-musleabihf.node'
#16 33.96     Require stack:
#16 33.96     - /var/www/anonaddy/node_modules/rolldown/dist/shared/binding-s-V_wTpj.mjs
#16 33.96         at Function._resolveFilename (node:internal/modules/cjs/loader:1383:15)
#16 33.96         at defaultResolveImpl (node:internal/modules/cjs/loader:1025:19)
#16 33.96         at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1030:22)
#16 33.96         at Function._load (node:internal/modules/cjs/loader:1192:37)
#16 33.96         at TracingChannel.traceSync (node:diagnostics_channel:328:14)
#16 33.96         at wrapModuleLoad (node:internal/modules/cjs/loader:237:24)
#16 33.96         at Module.require (node:internal/modules/cjs/loader:1463:12)
#16 33.96         at require (node:internal/modules/helpers:147:16)
#16 33.96         at requireNative (file:///var/www/anonaddy/node_modules/rolldown/dist/shared/binding-s-V_wTpj.mjs:316:12)
#16 33.96         at file:///var/www/anonaddy/node_modules/rolldown/dist/shared/binding-s-V_wTpj.mjs:475:18 {
#16 33.96       code: 'MODULE_NOT_FOUND',
#16 33.96       requireStack: [
#16 33.96         '/var/www/anonaddy/node_modules/rolldown/dist/shared/binding-s-V_wTpj.mjs'
#16 33.96       ]
#16 33.96     }
#16 33.96   }
#16 33.96 }
#16 33.96 
#16 33.96 Node.js v22.22.2
```

`vite@8` is loading Rolldown, and on Alpine arm32 it asks for the musl ARM native package (`@rolldown/binding-linux-arm-musleabihf`), which the installed dependency tree does not contain.