### PR TITLE
fix: multiple Postfix compatibility issues for v1.5.0 upgrade

### DIFF
--- a/rootfs/etc/cont-init.d/02-fix-perms.sh
+++ b/rootfs/etc/cont-init.d/02-fix-perms.sh
@@ -10,9 +10,9 @@ mkdir -p /data \
   /var/run/php-fpm
 chown anonaddy:anonaddy /data
 touch /data/postfix/mail.log
+chown anonaddy:anonaddy /data/postfix/mail.log
 chown -R anonaddy:anonaddy \
   /data/dkim \
-  /data/postfix \
   /tpls \
   /var/lib/nginx \
   /var/log/nginx \

--- a/rootfs/etc/cont-init.d/15-config-postfix.sh
+++ b/rootfs/etc/cont-init.d/15-config-postfix.sh
@@ -269,6 +269,15 @@ EOL
   postmap /etc/postfix/header_checks
 fi
 
+# Force Postfix MySQL maps to use the container's global database configuration
+for f in /etc/postfix/mysql-*.cf; do
+  if [ -f "$f" ]; then
+    echo "option_file = /etc/my.cnf" >> "$f"
+    echo "option_group = client" >> "$f"
+    echo "tls_verify_cert = no" >> "$f"
+  fi
+done
+
 if [ -f "/data/postfix-main.alt.cf" ]; then
   cat "/data/postfix-main.alt.cf" > /etc/postfix/main.cf
 fi

--- a/rootfs/etc/cont-init.d/61-svc-postfix.sh
+++ b/rootfs/etc/cont-init.d/61-svc-postfix.sh
@@ -2,6 +2,8 @@
 # shellcheck shell=bash
 set -e
 
+. $(dirname $0)/00-env
+
 mkdir -p /etc/services.d/postfix
 cat > /etc/services.d/postfix/run <<EOL
 #!/usr/bin/execlineb -P


### PR DESCRIPTION
### Description

This PR addresses three critical issues introduced in the `1.5.0` update that cause Postfix to fail its integrity check, enter a crash loop, or fail database lookups due to strict SSL enforcement in the new Alpine 3.23 environment.

**1. Recursive `chown` stripping Postfix queue permissions**
In `02-fix-perms.sh`, the `/data/postfix` directory was added to a recursive `chown -R anonaddy:anonaddy` command. This recursively stripped the internal `postfix` system user and `root` of their required ownership over the internal mail queue directories (`defer`, `active`, `maildrop`, `pid`). Because Postfix requires these directories to be strictly owned by `postfix` or `root`, it fails its integrity check on boot and crashes (`postsuper: fatal: scan_dir_push: open directory defer: Permission denied`)[cite: 1].
* **Fix:** Removed `/data/postfix` from the recursive `chown` block and applied the `anonaddy` ownership specifically to the `mail.log` file, preserving the internal queue permissions[cite: 1].

**2. Un-sourced environment variable breaking `postfix-logs`**
In `61-svc-postfix.sh`, the script generates the `run` file for the log service using the `$POSTFIX_LOG_PATH` variable. However, because `00-env` was not sourced at the top of the file, the variable was empty at runtime[cite: 1]. This resulted in the log service running the command `tail -F ` (with no file path attached), causing it to instantly crash and loop every second (`tail: standard input has been renamed or deleted`)[cite: 1].
* **Fix:** Added `. $(dirname $0)/00-env` to the top of `61-svc-postfix.sh` so the variable is correctly populated before generating the `run` file[cite: 1].

**3. MariaDB 3.4 SSL enforcement causing database lookup failures**
The upgrade to Alpine 3.23 introduced MariaDB Connector/C 3.4, which enforces stricter SSL/TLS verification by default[cite: 1]. Because Postfix MySQL maps are isolated, they ignore the global `skip-ssl.cnf` provided in the repository. This results in a `451 4.3.0 Temporary lookup failure` because Postfix attempts to verify a certificate even when the database server does not support SSL[cite: 1].
* **Fix:** Updated `15-config-postfix.sh` to explicitly link Postfix MySQL maps to the repository's existing `skip-ssl` policy via `option_file` and `option_group`, and added `tls_verify_cert = no` to prevent the engine from crashing on certificate verification[cite: 1].

### How to test

1. Build the image with these changes.
2. Run the container with persistent volumes mapped to `/data` (ensuring the `anonaddy` user and `postfix` user IDs map correctly to the host).
3. **Verify Boot:** Postfix will boot successfully without permission fatal errors[cite: 1].
4. **Verify Logs:** The `tail: standard input` log spam will no longer occur[cite: 1].
5. **Verify Delivery:** Send a test email to an alias. Confirm that Postfix successfully queries the database without `TLS/SSL error` warnings and delivers the mail[cite: 1].