### PR TITLE
disable Postfix MySQL certificate verification

### DIFF
--- a/rootfs/etc/cont-init.d/15-config-postfix.sh
+++ b/rootfs/etc/cont-init.d/15-config-postfix.sh
@@ -254,6 +254,7 @@ user = ${DB_USERNAME}
 password = ${DB_PASSWORD}
 hosts = ${DB_HOST}:${DB_PORT}
 dbname = ${DB_DATABASE}
+tls_verify_cert = no
 query = SELECT (SELECT 1 FROM usernames WHERE ${QUERY_USERNAMES}) AS usernames, (SELECT 1 FROM domains WHERE domain = '%s' AND domain_verified_at IS NOT NULL) AS domains LIMIT 1;
 EOL
 chmod o= /etc/postfix/mysql-virtual-alias-domains-and-subdomains.cf


### PR DESCRIPTION
This change disables server certificate verification for the generated Postfix MySQL lookup map.

The Postfix init script now writes `tls_verify_cert = no` directly into `/etc/postfix/mysql-virtual-alias-domains-and-subdomains.cf`. This does not change the query, credentials, database name, or Postfix routing behavior. It only relaxes certificate verification for this specific Postfix MySQL lookup map.

MariaDB Connector/C 3.4 verifies server certificates by default on non-local connections, which can break Postfix MySQL lookups after the Alpine 3.23 upgrade when the database connection does not have verifiable TLS configured.

The reason this matters now is the Alpine 3.23 upgrade. Alpine 3.23 brings MariaDB Connector/C 3.4.x, and that connector became stricter around TLS verification for non-local MariaDB connections. In a normal Docker Compose setup, the database host is something like `db`, not `localhost`, and the MariaDB container usually does not provide a certificate chain that the addy container can verify. So Postfix can fail the lookup even though the credentials, host, port, and query are all correct.