### PR TITLE
addy 1.6.1 to 1.6.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG ANONADDY_VERSION=1.6.1
+ARG ANONADDY_VERSION=1.6.2
 ARG ALPINE_VERSION=3.23
 
 FROM tianon/gosu:latest AS gosu


### PR DESCRIPTION
Update 1.6.1 to 1.6.2

https://github.com/anonaddy/anonaddy/releases/tag/v1.6.2