### PR TITLE
addy 1.6.1 to 1.6.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG ANONADDY_VERSION=1.6.1
+ARG ANONADDY_VERSION=1.6.3
 ARG ALPINE_VERSION=3.23
 
 FROM tianon/gosu:latest AS gosu


### PR DESCRIPTION
Bump AnonAddy to [v1.6.3](https://github.com/anonaddy/anonaddy/releases/tag/v1.6.3).

1.6.3

- Fixed PREG_JIT_STACKLIMIT_ERROR in `app/Mail/ReplyToEmail.php` https://github.com/anonaddy/anonaddy/issues/885
- Added option to disable bandwidth limit by setting `ANONADDY_BANDWIDTH_LIMIT_ENABLED=false` in your `.env` file
- Fixed missing return statements in v1.6.2

1.6.2

- Added description field to recipients - https://github.com/anonaddy/anonaddy/issues/879
- Added description underneath aliases on [failed deliveries](https://app.addy.io/failed-deliveries) page
- Fixed encryption issue with certify-only primary keys - https://github.com/anonaddy/anonaddy/issues/883
- Added failure reason to failed delivery notifications
- Made email validation consistent across front and backend - https://github.com/anonaddy/anonaddy/issues/876
- Improved handling of alias addresses in quoted email body
- Fixed recipient email tags' lengths when selecting a recipient - https://github.com/anonaddy/anonaddy/issues/888
- Fixed issue where toggle switches were not showing the correct state for screen readers
- Fixed issue where content IDs (cid) for inline image attachments were broken if they did not include an @ sign.